### PR TITLE
UIX2 과제 : banner API 지연에 따른 렌더링_Suspense 추가.

### DIFF
--- a/apps/rendering/src/component/Component.tsx
+++ b/apps/rendering/src/component/Component.tsx
@@ -1,21 +1,39 @@
 'use client';
 
-import {useEffect } from 'react';
-import {axios} from "../apis/axios";
+import { useEffect, useState } from 'react';
+import { axios } from '../apis/axios';
+import { promiseWrapper } from '../utils/promiseWrapper';
+
+interface IBanner {
+    id: number;
+    url: string;
+}
 
 const Component = () => {
-
+    const [banners, setBanners] = useState<IBanner[] | null>(null);
     useEffect(() => {
-    const getData = async () => {
-        const { data } = await axios.get('/api/banners');
+        const getData = async () => {
+            const { data } = await axios.get('/api/banners');
+            console.log(data);
 
-        console.log(data)
-    }
+            return data;
+        };
 
-    getData()
+        setBanners(promiseWrapper(getData()));
     }, []);
 
-    return <div>API Boiler Plate</div>
-}
+    return (
+        <div>
+            <div>API Boiler Plate</div>
+            {/* {
+                banners?.map((banner: IBanner) => (
+                    <div key={banner.id}>
+                        <img src={banner.url} alt={`${banner.id} image`} />
+                    </div>
+                ))
+            } */}
+        </div>
+    );
+};
 
 export default Component;

--- a/apps/rendering/src/pages/index.tsx
+++ b/apps/rendering/src/pages/index.tsx
@@ -1,9 +1,12 @@
 import { NextPage } from 'next';
+import { Suspense } from 'react';
 import Component from "../component/Component";
 
 const Home: NextPage = () => {
   return (
-    <Component/>
+    <Suspense fallback={<div>Loading...</div>}>
+      <Component />
+    </Suspense>
   );
 };
 

--- a/apps/rendering/src/utils/promiseWrapper.ts
+++ b/apps/rendering/src/utils/promiseWrapper.ts
@@ -1,0 +1,30 @@
+const promiseWrapper = (promise: Promise<any>): any => {
+    let status = 'pending';
+    let result: any;
+
+    const pending = promise.then(
+        (value) => {
+            status = 'success';
+            result = value;
+        },
+        (error) => {
+            status = 'error';
+            result = error;
+        }
+    );
+
+    return () => {
+        switch (status) {
+            case 'pending':
+                throw pending;
+            case 'success':
+                return result;
+            case 'error':
+                throw result;
+            default:
+                throw new Error('Unknown status');
+        }
+    };
+};
+
+export { promiseWrapper };


### PR DESCRIPTION
TGC UI/UX 시즌2 실습 과제입니다.

## Render 상태 관리.
- 상태관리는 별도의 라이브러리 없이 React.useState 활용하였습니다.

## Banner API 호출 지연 관련.
- Banner API 호출 시 발생하는 1초 Delay에 대응하기 위해 React.Suspense 추가하여 fallback으로 Loading 문구 표시되도록 내부 동작 변경하였습니다.

## React.Suspense 사용을 위한 promiseWrapper?
- axios를 통한 데이터 fetch 동작을 모니터링하기 위한 유틸리티입니다.
- 주어진 promise가 모두 처리되기 전까지는 _suspenser_pending_을, 모두 처리된 이후에는 처리 결과를, 처리되지 않은 경우 _Error_를 throw합니다.
- 이 때 throw된 Error는 _ErrorBoundary_를 활용하여 해결할 수 있으나, 본 커밋에서는 적용하지 않았습니다.
- suspenser가 throw된 경우 가장 가까운 React.Suspense에서 fallback을 보여주도록 처리됩니다.